### PR TITLE
fix: get blocked when creating new view in windows

### DIFF
--- a/src-tauri/src/new_sender.rs
+++ b/src-tauri/src/new_sender.rs
@@ -1,7 +1,7 @@
 use tauri::Wry;
 
 #[tauri::command]
-pub fn create_sender_window(app_handle: tauri::AppHandle<Wry>) {
+pub async fn create_sender_window(app_handle: tauri::AppHandle<Wry>) {
     let viewer = tauri::WindowBuilder::new(
         &app_handle,
         "senderWindow",

--- a/src-tauri/src/new_view.rs
+++ b/src-tauri/src/new_view.rs
@@ -1,7 +1,7 @@
 use tauri::{Manager, Wry};
 
 #[tauri::command]
-pub fn create_new_danmaku_view(app_handle: tauri::AppHandle<Wry>) {
+pub async fn create_new_danmaku_view(app_handle: tauri::AppHandle<Wry>) {
     let viewer = tauri::WindowBuilder::new(
         &app_handle,
         "danmakuWidget",


### PR DESCRIPTION
When creating a new danmaku show widget in windows 10, it seems get infinite blocked.

Then I see this issue https://github.com/tauri-apps/tauri/issues/4121 , and change this command to async.

My test environment:

```text
Environment
  › OS: Windows 10.0.19043 X64
  › Webview2: 105.0.1343.42
  › MSVC:
      - Visual Studio ???? 2019
  › Node.js: 16.17.0
  › npm: 8.15.0
  › pnpm: 7.11.0
  › yarn: 1.22.18
  › rustup: 1.25.1
  › rustc: 1.63.0
  › cargo: 1.63.0
  › Rust toolchain: stable-x86_64-pc-windows-msvc

Packages
  › @tauri-apps/cli [NPM]: 1.1.0 (outdated, latest: 1.1.1)
  › @tauri-apps/api [NPM]: 1.1.0
  › tauri [RUST]: 1.1.0,
  › tauri-build [RUST]: 1.1.0,
  › tao [RUST]: 0.14.0,
  › wry [RUST]: 0.21.1,

App
  › build-type: bundle
  › CSP: unset
  › distDir: ../dist
  › devPath: http://localhost:5173/
  › framework: Vue.js

App directory structure
  ├─ .git
  ├─ .github
  ├─ .vscode
  ├─ dist
  ├─ imgs
  ├─ node_modules
  ├─ public
  ├─ src
  └─ src-tauri
```